### PR TITLE
Fixed toroidal wrapping for sparse grid.

### DIFF
--- a/mason/sim/field/grid/SparseGrid2D.java
+++ b/mason/sim/field/grid/SparseGrid2D.java
@@ -1266,7 +1266,7 @@ public class SparseGrid2D extends SparseField implements Grid2D, SparseField2D
                 int _x = xPos.get(i);
                 int _y = yPos.get(i);
                 xPos.set(i, tx(_x, width, widthtimestwo, _x + width, _x - width));
-                yPos.set(i, tx(_y, height, heighttimestwo, _y + width, _y - width));
+                yPos.set(i, ty(_y, height, heighttimestwo, _y + height, _y - height));
                 }
             }
         }


### PR DESCRIPTION
See Fix in #6 : SparseGrid2D has a significant amount of duplicated code from AbstractGrid2D.