### PR TITLE
Fix reading geoTiff

### DIFF
--- a/contrib/geomason/sim/io/geo/GDALImporter.java
+++ b/contrib/geomason/sim/io/geo/GDALImporter.java
@@ -125,7 +125,7 @@ public class GDALImporter
 
         for (int currRow = 0; currRow < ySize; currRow++)
         {
-            //result = band.ReadRaster(0, currRow, xSize, 1, line);
+            result = band.ReadRaster(0, currRow, xSize, 1, line);
             if (result != gdalconstConstants.CE_None)
             {
                 throw new RuntimeException("Problem reading raster");
@@ -158,7 +158,7 @@ public class GDALImporter
 
         for (int currRow = 0; currRow < ySize; currRow++)
         {
-            //result = band.ReadRaster(0, currRow, xSize, 1, line);
+            result = band.ReadRaster(0, currRow, xSize, 1, line);
             if (result != gdalconstConstants.CE_None)
             {
                 throw new RuntimeException("Problem reading raster");


### PR DESCRIPTION
When reading geoTiff all grid values were set to 0.0 due to commenting out relevant code.

More specifically: `band.ReadRaster()` sets the values for the double array `line`. When not calling the function, line will only be an array of `0.0` and its values will be added to the grid, ignoring the actual values of the rasterband.

This code was commented out 9 years ago in https://github.com/eclab/mason/commit/d7a644259d6b4c02aaba8b3a787a4e72da63381c. I am not sure if this fix will have side effects on that commit.