### PR TITLE
Create CI configuration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: "Build"
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 6 * * 1' # Run every monday at 06:00 UTC
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu, windows, macos]
+        node: ['16']
+        include:
+          - os: ubuntu
+            node: '17'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: mvn clean install


### PR DESCRIPTION
Builds MASON on Ubuntu, Windows and macOS using Node.JS 16 LTS, and also on Ubuntu for Node.JS 17. It runs on every push, pull request and once a week.