### PR TITLE
Set properties before simState start

### DIFF
--- a/mason/src/main/java/sim/util/sweep/ParameterSweep.java
+++ b/mason/src/main/java/sim/util/sweep/ParameterSweep.java
@@ -455,6 +455,7 @@ class ParameterSweepSimulationJob
     
     public void run(SimState simState, sim.util.Properties properties, ArrayList<Double> combos) 
         {
+        properties = initSweepValuesFromProperties(properties);
         simState.start();
         properties = initSweepValuesFromProperties(properties);
         for(int i = 0; i< sweep.numSteps; i++)


### PR DESCRIPTION
When using parameter sweep, the model properties are set after the `start()` method, so within `start()` all the properties have the default values.